### PR TITLE
feat(#14): enforce required-check merge gate

### DIFF
--- a/src/integrations/openai/codex.ts
+++ b/src/integrations/openai/codex.ts
@@ -153,15 +153,20 @@ baseline_commit: ${params.baselineCommit}
     reviewSummary: string;
     requiredChecksPassed: boolean;
   }): Promise<MergeDecisionV1> {
+    if (!params.requiredChecksPassed) {
+      return MergeDecisionV1Schema.parse({
+        decision: 'request_changes',
+        rationale:
+          'Required checks gate failed: merge approval is blocked until all required checks pass.',
+        blocking_findings: ['One or more required checks are pending or failing.'],
+      });
+    }
+
     if (this.dryRun || !this.hasApiKey) {
       return MergeDecisionV1Schema.parse({
-        decision: params.requiredChecksPassed ? 'approve' : 'request_changes',
-        rationale: params.requiredChecksPassed
-          ? 'Required checks passed in dry-run mode.'
-          : 'Required checks have not passed yet.',
-        blocking_findings: params.requiredChecksPassed
-          ? []
-          : ['One or more required checks are pending or failing.'],
+        decision: 'approve',
+        rationale: 'Required checks passed in dry-run mode.',
+        blocking_findings: [],
       });
     }
 

--- a/test/merge-decision-gating.test.ts
+++ b/test/merge-decision-gating.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CodexAdapter } from '../src/integrations/openai/codex.js';
+
+describe('CodexAdapter merge decision gate', () => {
+  it('hard-blocks approval when required checks are not passed', async () => {
+    const adapter = new CodexAdapter({ apiKey: 'test-key', model: 'gpt-5.3-codex' }, false);
+    const create = vi.fn().mockResolvedValue({
+      output_text: '{"decision":"approve","rationale":"ok","blocking_findings":[]}',
+    });
+
+    (
+      adapter as unknown as {
+        client: { responses: { create: typeof create } };
+      }
+    ).client = {
+      responses: { create },
+    };
+
+    const decision = await adapter.generateMergeDecision({
+      reviewSummary: 'All good except required checks pending.',
+      requiredChecksPassed: false,
+    });
+
+    expect(decision.decision).toBe('request_changes');
+    expect(decision.blocking_findings).toContain('One or more required checks are pending or failing.');
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('delegates to model once required checks pass', async () => {
+    const adapter = new CodexAdapter({ apiKey: 'test-key', model: 'gpt-5.3-codex' }, false);
+    const create = vi.fn().mockResolvedValue({
+      output_text: '{"decision":"approve","rationale":"All checks passed.","blocking_findings":[]}',
+    });
+
+    (
+      adapter as unknown as {
+        client: { responses: { create: typeof create } };
+      }
+    ).client = {
+      responses: { create },
+    };
+
+    const decision = await adapter.generateMergeDecision({
+      reviewSummary: 'Checks passed and no blockers.',
+      requiredChecksPassed: true,
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(decision.decision).toBe('approve');
+    expect(decision.blocking_findings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a hard required-check gate before merge decision generation
- return deterministic `request_changes` when required checks are pending/failing
- keep model-driven merge decision generation only for the checks-passed path
- add regression tests for blocked and checks-passed paths

## Validation
- npm run test
- npm run typecheck

Closes #14