### PR TITLE
test(#19): observability contract and runbook baseline

### DIFF
--- a/docs/observability-runbook.md
+++ b/docs/observability-runbook.md
@@ -1,0 +1,51 @@
+# Observability Contract and Runbook
+
+## Scope
+Baseline operational contract for the orchestration pipeline:
+`webhook -> spec generation -> task execution -> merge decision`.
+
+## Contract: Signals
+
+### Health and readiness endpoints
+1. `GET /healthz`
+Expected: `200`, body contains `status=ok`.
+2. `GET /readyz`
+Expected: `200` when DB is reachable, otherwise `503` with `status=not_ready`.
+
+### Metrics endpoint
+1. `GET /metrics`
+Expected content type: Prometheus text format.
+Required metrics:
+1. `ralph_workflow_runs_total{status=...}`
+2. `ralph_workflow_run_duration_ms`
+3. `ralph_webhook_events_total{event_type,result}`
+4. `ralph_retries_total{operation}`
+
+### Log safety contract
+1. Secrets and token-like strings must be redacted before persistence or outbound review comments.
+2. Dead-letter and failure logs should include redacted reason text and correlation fields:
+`event_id`, `run_id`, `task_id`.
+
+## Operational checks
+Run before and after deploy:
+1. `npm run test -- test/observability-contract.test.ts`
+2. `curl -sf http://localhost:3000/healthz`
+3. `curl -sf http://localhost:3000/readyz`
+4. `curl -sf http://localhost:3000/metrics | rg 'ralph_(workflow_runs_total|workflow_run_duration_ms|webhook_events_total|retries_total)'`
+
+## Incident triage
+
+### Symptom: webhook accepted but no run progress
+1. Check `ralph_webhook_events_total{result="accepted"}` growth.
+2. Check `ralph_workflow_runs_total` for `dead_letter` increase.
+3. Query most recent run via `GET /api/runs/:runId` and inspect `currentStage`.
+
+### Symptom: retries spiking
+1. Inspect `ralph_retries_total` by `operation`.
+2. Review recent dead-letter reasons for deterministic failures (schema/contract issues).
+3. Confirm required-check integrations and external provider status.
+
+### Symptom: readiness failures
+1. Validate database connectivity and credentials.
+2. Confirm migration state and DB health.
+3. Keep service out of rotation until `GET /readyz` returns `200`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,6 +18,7 @@ Set required variables from `.env.example`.
 - Health:
   - `GET /healthz`
   - `GET /readyz`
+- Runbook: see `docs/observability-runbook.md` for signal contract and incident checks.
 
 ## Security checks
 

--- a/test/observability-contract.test.ts
+++ b/test/observability-contract.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildServer } from '../src/api/server.js';
+import { createLogger } from '../src/lib/logger.js';
+
+const config = {
+  nodeEnv: 'test' as const,
+  port: 3000,
+  logLevel: 'silent' as const,
+  databaseUrl: 'postgres://example',
+  github: {
+    webhookSecret: 'test-secret',
+    appId: '1',
+    appPrivateKey: 'key',
+    installationId: 1,
+    targetOwner: 'khenson99',
+    targetRepo: 'ralph-loop-orchestrator',
+    baseBranch: 'main',
+  },
+  openai: { apiKey: 'k', model: 'm' },
+  anthropic: { apiKey: 'k', model: 'm' },
+  autoMergeEnabled: true,
+  requiredChecks: [],
+  otelEnabled: false,
+  dryRun: true,
+};
+
+function buildTestServer(dbReady: boolean) {
+  return buildServer({
+    config,
+    dbClient: { ready: async () => dbReady },
+    workflowRepo: {
+      getRunView: async () => null,
+      getTaskView: async () => null,
+      recordEventIfNew: async () => ({ inserted: true, eventId: 'evt-1' }),
+    },
+    orchestrator: { enqueue: () => {} },
+    logger: createLogger('silent'),
+  });
+}
+
+describe('observability contract', () => {
+  it('exposes health and readiness endpoints with expected status semantics', async () => {
+    const healthyApp = buildTestServer(true);
+    const health = await healthyApp.inject({ method: 'GET', url: '/healthz' });
+    const ready = await healthyApp.inject({ method: 'GET', url: '/readyz' });
+
+    expect(health.statusCode).toBe(200);
+    expect(JSON.parse(health.body)).toMatchObject({ status: 'ok' });
+    expect(ready.statusCode).toBe(200);
+    expect(JSON.parse(ready.body)).toMatchObject({ status: 'ready' });
+    await healthyApp.close();
+
+    const notReadyApp = buildTestServer(false);
+    const notReady = await notReadyApp.inject({ method: 'GET', url: '/readyz' });
+    expect(notReady.statusCode).toBe(503);
+    expect(JSON.parse(notReady.body)).toMatchObject({ status: 'not_ready' });
+    await notReadyApp.close();
+  });
+
+  it('publishes required Prometheus metrics at /metrics', async () => {
+    const app = buildTestServer(true);
+    const response = await app.inject({ method: 'GET', url: '/metrics' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('text/plain');
+    expect(response.body).toContain('ralph_workflow_runs_total');
+    expect(response.body).toContain('ralph_workflow_run_duration_ms');
+    expect(response.body).toContain('ralph_webhook_events_total');
+    expect(response.body).toContain('ralph_retries_total');
+
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add observability contract test coverage for `/healthz`, `/readyz`, and `/metrics`
- verify required Prometheus metrics are exposed on `/metrics`
- add baseline operational runbook for telemetry checks and incident triage
- link operations guide to the runbook

## Validation
- npm run test
- npm run typecheck

Closes #19