### PR TITLE
feat(#20): kanban board foundation with lane filters and card projections

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -15,6 +15,7 @@ import {
   TaskResponseSchema,
   type WebhookEventEnvelope,
 } from '../schemas/contracts.js';
+import { BOARD_LANES, groupCardsByLane, projectBoardCards } from '../ui/kanban-model.js';
 
 export type AppServices = {
   config: AppConfig;
@@ -65,6 +66,25 @@ export type AppServices = {
       sourceRepo: string;
       payload: Record<string, unknown>;
     }) => Promise<{ inserted: boolean; eventId: string }>;
+    listBoardCards?: (
+      limit?: number,
+    ) => Promise<
+      Array<{
+        runId: string;
+        issueNumber: number | null;
+        prNumber: number | null;
+        status: string;
+        currentStage: string;
+        updatedAt: string;
+        taskCounts: {
+          queued: number;
+          running: number;
+          retry: number;
+          completed: number;
+          failed: number;
+        };
+      }>
+    >;
   };
   orchestrator: {
     enqueue: (item: { eventId: string; envelope: WebhookEventEnvelope }) => void;
@@ -95,6 +115,154 @@ export function buildServer(services: AppServices) {
   app.get('/metrics', async (_, reply) => {
     reply.header('Content-Type', metricsRegistry.contentType);
     return metricsRegistry.metrics();
+  });
+
+  app.get('/api/board/cards', async (request) => {
+    const query = request.query as {
+      q?: string;
+      lane?: string;
+      status?: string;
+      limit?: string;
+    };
+
+    const parsedLimit = query.limit ? Number.parseInt(query.limit, 10) : 100;
+    const limit = Number.isFinite(parsedLimit) ? parsedLimit : 100;
+    const cards = services.workflowRepo.listBoardCards
+      ? await services.workflowRepo.listBoardCards(limit)
+      : [];
+    const projected = projectBoardCards(cards, {
+      query: query.q,
+      lane: query.lane,
+      status: query.status,
+    });
+
+    return {
+      lanes: BOARD_LANES,
+      cards: projected,
+      grouped: groupCardsByLane(projected),
+    };
+  });
+
+  app.get('/supervisor', async (_, reply) => {
+    reply.type('text/html');
+    return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ralph Supervisor Board</title>
+  <style>
+    :root {
+      --bg: #0b1220;
+      --panel: #111a2e;
+      --muted: #8fa3c8;
+      --text: #dbe7ff;
+      --accent: #4db3ff;
+      --ok: #14b85a;
+      --warn: #f59e0b;
+      --danger: #ef4444;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif; background: radial-gradient(circle at top left, #162649 0%, var(--bg) 45%); color: var(--text); }
+    .container { padding: 20px; max-width: 1600px; margin: 0 auto; }
+    .toolbar { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 16px; }
+    .toolbar input, .toolbar select, .toolbar button { background: #0d1730; color: var(--text); border: 1px solid #233456; border-radius: 10px; padding: 10px 12px; }
+    .board { display: grid; grid-template-columns: repeat(5, minmax(220px, 1fr)); gap: 12px; align-items: start; }
+    .lane { background: rgba(17, 26, 46, 0.92); border: 1px solid #27395f; border-radius: 14px; min-height: 320px; }
+    .lane-head { padding: 12px; border-bottom: 1px solid #243758; }
+    .lane-title { margin: 0; font-size: 15px; }
+    .lane-sub { margin: 4px 0 0; color: var(--muted); font-size: 12px; }
+    .lane-count { float: right; color: var(--accent); font-weight: 700; }
+    .cards { padding: 10px; display: grid; gap: 10px; }
+    .card { border: 1px solid #2b3f67; border-radius: 12px; background: #0e1a35; padding: 10px; }
+    .card h4 { margin: 0 0 6px; font-size: 14px; }
+    .meta { font-size: 12px; color: var(--muted); margin-bottom: 6px; }
+    .badges { display: flex; gap: 6px; flex-wrap: wrap; }
+    .badge { font-size: 11px; padding: 3px 7px; border-radius: 999px; background: #1d2f4e; border: 1px solid #324c78; }
+    .badge.ok { color: #bcffd6; border-color: #1f8f4a; background: rgba(20,184,90,0.12); }
+    .badge.warn { color: #ffe7b0; border-color: #9a6a11; background: rgba(245,158,11,0.12); }
+    .badge.danger { color: #ffd2d2; border-color: #a02323; background: rgba(239,68,68,0.12); }
+    @media (max-width: 1200px) { .board { grid-template-columns: repeat(3, minmax(220px, 1fr)); } }
+    @media (max-width: 860px) { .board { grid-template-columns: repeat(1, minmax(220px, 1fr)); } }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Ralph Supervisor Board</h1>
+    <div class="toolbar">
+      <input id="q" placeholder="Search run/issue/PR/stage" />
+      <select id="lane">
+        <option value="">All lanes</option>
+        <option value="ingest">Ingest</option>
+        <option value="execute">Execute</option>
+        <option value="review">Review</option>
+        <option value="blocked">Blocked</option>
+        <option value="done">Done</option>
+      </select>
+      <select id="status">
+        <option value="">All statuses</option>
+        <option value="in_progress">in_progress</option>
+        <option value="completed">completed</option>
+        <option value="dead_letter">dead_letter</option>
+        <option value="failed">failed</option>
+      </select>
+      <button id="refresh">Refresh</button>
+    </div>
+    <div id="board" class="board"></div>
+  </div>
+  <script>
+    const boardEl = document.getElementById('board');
+    const qEl = document.getElementById('q');
+    const laneEl = document.getElementById('lane');
+    const statusEl = document.getElementById('status');
+    const refreshEl = document.getElementById('refresh');
+    async function load() {
+      const params = new URLSearchParams();
+      if (qEl.value) params.set('q', qEl.value);
+      if (laneEl.value) params.set('lane', laneEl.value);
+      if (statusEl.value) params.set('status', statusEl.value);
+      const response = await fetch('/api/board/cards?' + params.toString());
+      const data = await response.json();
+      render(data);
+    }
+    function badgeClass(value) {
+      if (value.includes('dead') || value.includes('failed')) return 'danger';
+      if (value.includes('completed')) return 'ok';
+      return 'warn';
+    }
+    function render(data) {
+      boardEl.innerHTML = '';
+      for (const lane of data.lanes) {
+        const cards = data.grouped[lane.id] || [];
+        const laneEl = document.createElement('section');
+        laneEl.className = 'lane';
+        laneEl.innerHTML = '<div class="lane-head"><p class="lane-count">' + cards.length + '</p><h3 class="lane-title">' + lane.title + '</h3><p class="lane-sub">' + lane.description + '</p></div>';
+        const cardsEl = document.createElement('div');
+        cardsEl.className = 'cards';
+        for (const card of cards) {
+          const issueLabel = card.issueNumber ? '#' + card.issueNumber : 'No issue';
+          const prLabel = card.prNumber ? 'PR #' + card.prNumber : 'No PR';
+          const taskStats = card.taskCounts ? 'done:' + card.taskCounts.completed + ' retry:' + card.taskCounts.retry + ' running:' + card.taskCounts.running : '';
+          const el = document.createElement('article');
+          el.className = 'card';
+          el.innerHTML = '<h4>' + issueLabel + ' · ' + card.runId.slice(0, 8) + '</h4>'
+            + '<div class="meta">' + prLabel + ' · ' + new Date(card.updatedAt).toLocaleString() + '</div>'
+            + '<div class="badges"><span class="badge ' + badgeClass(card.status) + '">' + card.status + '</span>'
+            + '<span class="badge">' + card.currentStage + '</span><span class="badge">' + taskStats + '</span></div>';
+          cardsEl.appendChild(el);
+        }
+        laneEl.appendChild(cardsEl);
+        boardEl.appendChild(laneEl);
+      }
+    }
+    qEl.addEventListener('input', () => load());
+    laneEl.addEventListener('change', () => load());
+    statusEl.addEventListener('change', () => load());
+    refreshEl.addEventListener('click', () => load());
+    load();
+  </script>
+</body>
+</html>`;
   });
 
   app.get('/api/runs/:runId', async (request, reply) => {

--- a/src/ui/kanban-model.ts
+++ b/src/ui/kanban-model.ts
@@ -1,0 +1,106 @@
+export type BoardCard = {
+  runId: string;
+  issueNumber: number | null;
+  prNumber: number | null;
+  status: string;
+  currentStage: string;
+  updatedAt: string;
+  taskCounts: {
+    queued: number;
+    running: number;
+    retry: number;
+    completed: number;
+    failed: number;
+  };
+};
+
+export type BoardLane = {
+  id: string;
+  title: string;
+  description: string;
+};
+
+export type BoardFilters = {
+  query?: string;
+  lane?: string;
+  status?: string;
+};
+
+export type ProjectedBoardCard = BoardCard & {
+  lane: string;
+};
+
+export const BOARD_LANES: BoardLane[] = [
+  { id: 'ingest', title: 'Ingest', description: 'Webhook intake and spec setup.' },
+  { id: 'execute', title: 'Execute', description: 'Tasks dispatched and running.' },
+  { id: 'review', title: 'Review', description: 'PR and merge-decision phase.' },
+  { id: 'blocked', title: 'Blocked', description: 'Dead-letter or failed orchestration.' },
+  { id: 'done', title: 'Done', description: 'Completed workflow runs.' },
+];
+
+export function deriveLane(card: BoardCard): string {
+  if (card.status === 'completed') {
+    return 'done';
+  }
+
+  if (card.status === 'dead_letter' || card.currentStage === 'DeadLetter') {
+    return 'blocked';
+  }
+
+  if (card.currentStage === 'PRReviewed' || card.currentStage === 'MergeDecision') {
+    return 'review';
+  }
+
+  if (card.currentStage === 'SubtasksDispatched') {
+    return 'execute';
+  }
+
+  if (card.currentStage === 'TaskRequested' || card.currentStage === 'SpecGenerated') {
+    return 'ingest';
+  }
+
+  return 'execute';
+}
+
+export function projectBoardCards(cards: BoardCard[], filters: BoardFilters): ProjectedBoardCard[] {
+  const query = (filters.query ?? '').trim().toLowerCase();
+  const lane = (filters.lane ?? '').trim();
+  const status = (filters.status ?? '').trim().toLowerCase();
+
+  return cards
+    .map((card) => ({ ...card, lane: deriveLane(card) }))
+    .filter((card) => (lane ? card.lane === lane : true))
+    .filter((card) => (status ? card.status.toLowerCase() === status : true))
+    .filter((card) => {
+      if (!query) {
+        return true;
+      }
+
+      const searchable = [
+        card.runId,
+        card.issueNumber ? `#${card.issueNumber}` : '',
+        card.prNumber ? `#${card.prNumber}` : '',
+        card.status,
+        card.currentStage,
+      ]
+        .join(' ')
+        .toLowerCase();
+
+      return searchable.includes(query);
+    })
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+}
+
+export function groupCardsByLane(cards: ProjectedBoardCard[]): Record<string, ProjectedBoardCard[]> {
+  const grouped: Record<string, ProjectedBoardCard[]> = {};
+  for (const lane of BOARD_LANES) {
+    grouped[lane.id] = [];
+  }
+
+  for (const card of cards) {
+    const laneCards = grouped[card.lane] ?? (grouped[card.lane] = []);
+    laneCards.push(card);
+  }
+
+  return grouped;
+}

--- a/test/kanban-model.test.ts
+++ b/test/kanban-model.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveLane, groupCardsByLane, projectBoardCards, type BoardCard } from '../src/ui/kanban-model.js';
+
+const cards: BoardCard[] = [
+  {
+    runId: 'run-ingest',
+    issueNumber: 20,
+    prNumber: null,
+    status: 'in_progress',
+    currentStage: 'TaskRequested',
+    updatedAt: '2026-02-12T00:00:00.000Z',
+    taskCounts: { queued: 1, running: 0, retry: 0, completed: 0, failed: 0 },
+  },
+  {
+    runId: 'run-review',
+    issueNumber: 21,
+    prNumber: 40,
+    status: 'in_progress',
+    currentStage: 'PRReviewed',
+    updatedAt: '2026-02-12T00:10:00.000Z',
+    taskCounts: { queued: 0, running: 0, retry: 1, completed: 2, failed: 0 },
+  },
+  {
+    runId: 'run-done',
+    issueNumber: 22,
+    prNumber: 41,
+    status: 'completed',
+    currentStage: 'MergeDecision',
+    updatedAt: '2026-02-12T00:20:00.000Z',
+    taskCounts: { queued: 0, running: 0, retry: 0, completed: 3, failed: 0 },
+  },
+];
+
+describe('kanban model', () => {
+  it('derives lanes from status and stage', () => {
+    expect(deriveLane(cards[0]!)).toBe('ingest');
+    expect(deriveLane(cards[1]!)).toBe('review');
+    expect(deriveLane(cards[2]!)).toBe('done');
+  });
+
+  it('applies query/lane/status filters and sorts newest first', () => {
+    const projected = projectBoardCards(cards, {
+      query: '#2',
+      lane: 'review',
+      status: 'in_progress',
+    });
+    expect(projected).toHaveLength(1);
+    expect(projected[0]).toBeDefined();
+    expect(projected[0]!.runId).toBe('run-review');
+
+    const sorted = projectBoardCards(cards, {});
+    expect(sorted.map((c) => c.runId)).toEqual(['run-done', 'run-review', 'run-ingest']);
+  });
+
+  it('groups projected cards by lane buckets', () => {
+    const grouped = groupCardsByLane(projectBoardCards(cards, {}));
+    expect(grouped.ingest).toHaveLength(1);
+    expect(grouped.review).toHaveLength(1);
+    expect(grouped.done).toHaveLength(1);
+  });
+});

--- a/test/supervisor-board.test.ts
+++ b/test/supervisor-board.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildServer } from '../src/api/server.js';
+import { createLogger } from '../src/lib/logger.js';
+
+const config = {
+  nodeEnv: 'test' as const,
+  port: 3000,
+  logLevel: 'silent' as const,
+  databaseUrl: 'postgres://example',
+  github: {
+    webhookSecret: 'test-secret',
+    appId: '1',
+    appPrivateKey: 'key',
+    installationId: 1,
+    targetOwner: 'khenson99',
+    targetRepo: 'ralph-loop-orchestrator',
+    baseBranch: 'main',
+  },
+  openai: { apiKey: 'k', model: 'm' },
+  anthropic: { apiKey: 'k', model: 'm' },
+  autoMergeEnabled: true,
+  requiredChecks: [],
+  otelEnabled: false,
+  dryRun: true,
+};
+
+describe('supervisor kanban board endpoints', () => {
+  it('returns projected cards grouped by lane from /api/board/cards', async () => {
+    const app = buildServer({
+      config,
+      dbClient: { ready: async () => true },
+      workflowRepo: {
+        getRunView: async () => null,
+        getTaskView: async () => null,
+        recordEventIfNew: async () => ({ inserted: true, eventId: 'evt-1' }),
+        listBoardCards: async () => [
+          {
+            runId: 'run-1',
+            issueNumber: 20,
+            prNumber: null,
+            status: 'in_progress',
+            currentStage: 'TaskRequested',
+            updatedAt: new Date('2026-02-12T07:00:00.000Z').toISOString(),
+            taskCounts: { queued: 1, running: 0, retry: 0, completed: 0, failed: 0 },
+          },
+          {
+            runId: 'run-2',
+            issueNumber: 21,
+            prNumber: 55,
+            status: 'completed',
+            currentStage: 'MergeDecision',
+            updatedAt: new Date('2026-02-12T08:00:00.000Z').toISOString(),
+            taskCounts: { queued: 0, running: 0, retry: 0, completed: 2, failed: 0 },
+          },
+        ],
+      },
+      orchestrator: { enqueue: () => {} },
+      logger: createLogger('silent'),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/board/cards?lane=done',
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      lanes: Array<{ id: string }>;
+      cards: Array<{ runId: string; lane: string }>;
+      grouped: Record<string, Array<{ runId: string }>>;
+    };
+    expect(body.lanes.length).toBeGreaterThan(0);
+    expect(body.cards).toHaveLength(1);
+    expect(body.cards[0]).toMatchObject({ runId: 'run-2', lane: 'done' });
+    const doneCards = body.grouped.done;
+    expect(doneCards).toBeDefined();
+    expect(doneCards).toHaveLength(1);
+    expect(doneCards![0]).toMatchObject({ runId: 'run-2' });
+
+    await app.close();
+  });
+
+  it('serves supervisor board shell from /supervisor', async () => {
+    const app = buildServer({
+      config,
+      dbClient: { ready: async () => true },
+      workflowRepo: {
+        getRunView: async () => null,
+        getTaskView: async () => null,
+        recordEventIfNew: async () => ({ inserted: true, eventId: 'evt-1' }),
+      },
+      orchestrator: { enqueue: () => {} },
+      logger: createLogger('silent'),
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/supervisor',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('text/html');
+    expect(response.body).toContain('Ralph Supervisor Board');
+    expect(response.body).toContain('/api/board/cards');
+
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add supervisor board foundation with lane configuration and filter controls
- add `/api/board/cards` endpoint returning projected/grouped run cards for kanban rendering
- add `/supervisor` board shell with search, lane/status filters, and projected card columns
- add kanban model and route tests for lane derivation, filtering, grouping, and board contract

## Technical Notes
- Introduces `listBoardCards()` in repository and `src/ui/kanban-model.ts` for reusable projection logic.
- Contract assumption: board cards are projected from workflow runs + task status counts.

## Validation
- npm run test
- npm run typecheck

Closes #20