### PR TITLE
feat(#27): role-aware permission gating and forbidden action states

### DIFF
--- a/test/supervisor-run-detail.test.ts
+++ b/test/supervisor-run-detail.test.ts
@@ -74,6 +74,7 @@ describe('supervisor run detail page', () => {
     expect(response.body).toContain('Logs Viewer');
     expect(response.body).toContain('Action Controls');
     expect(response.body).toContain('Approve PR');
+    expect(response.body).toContain('roleSelect');
     expect(response.body).toContain('/api/runs/');
     expect(response.body).toContain('/logs');
     expect(response.body).toContain('/api/runs/');


### PR DESCRIPTION
## Summary
- enforce role-based action policy in run action API (`viewer`, `operator`, `admin`)
- reject forbidden actions with explicit `403 forbidden_action` responses
- add role selector and disabled forbidden-action UX states in detail page controls
- extend action/control tests for role-based authorization behavior

## Technical Notes
- Policy: `approve` => admin only, `request_changes`/`block` => operator or admin.
- UI and API both enforce policy to prevent client-side bypass.

## Validation
- npm run test
- npm run typecheck

Closes #27