### PR TITLE
feat(#56): add agent console drilldown and transcript navigation

### DIFF
--- a/test/supervisor-run-detail.test.ts
+++ b/test/supervisor-run-detail.test.ts
@@ -73,6 +73,11 @@ describe('supervisor run detail page', () => {
     expect(response.body).toContain('PR and CI Status');
     expect(response.body).toContain('Logs Viewer');
     expect(response.body).toContain('Agent Transcript (Read-only)');
+    expect(response.body).toContain('Agent Console v1');
+    expect(response.body).toContain('agentTaskFilter');
+    expect(response.body).toContain('agentPrevAttempt');
+    expect(response.body).toContain('agentNextAttempt');
+    expect(response.body).toContain('agentToolSummary');
     expect(response.body).toContain('auditExport');
     expect(response.body).toContain('Action Controls');
     expect(response.body).toContain('Approve PR');


### PR DESCRIPTION
## Summary
- add Agent Console v1 section on run detail page with task-filtered attempt timeline drilldown
- add transcript navigation controls (prev/next attempt + task selector) backed by existing run logs
- add tool call summaries derived from attempt payloads (commands + files changed)
- keep console read-only and sourced from persisted attempt/artifact logs

## Testing
- npm test -- test/supervisor-run-detail.test.ts test/supervisor-happy-path.integration.test.ts test/accessibility-baseline.test.ts

Closes #56
